### PR TITLE
Invalidate the mis-parsed Eneco injection snapshot cache (#35)

### DIFF
--- a/custom_components/be_electricity_prices/coordinator.py
+++ b/custom_components/be_electricity_prices/coordinator.py
@@ -2703,7 +2703,12 @@ async def _compute_current_year_cost(
 # v12: InjectionRates gained per-slot peak/transition/offpeak (Engie
 # Empower Flextime's per-slot feed-in tariff). Bump so a cached Flextime
 # snapshot is re-fetched with the triplet instead of the flat single rate.
-_SNAPSHOT_SCHEMA_VERSION = 12
+# v13: the July 2026 Eneco cards dropped the "/ VALORISATIE" suffix from
+# the injection heading, so 0.8.3 parsed every Eneco injection to None and
+# cached it. 0.8.4 fixed the anchor but probe-based freshness keeps serving
+# that stale None until Eneco republishes. Bump so the mis-parsed snapshot
+# is dropped and re-fetched with the injection block populated.
+_SNAPSHOT_SCHEMA_VERSION = 13
 
 
 def _snapshot_to_dict(

--- a/custom_components/be_electricity_prices/manifest.json
+++ b/custom_components/be_electricity_prices/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/renaudallard/homeassistant_be_electricity_prices/issues",
   "requirements": ["pypdf>=4.0", "pdfplumber>=0.11", "defusedxml>=0.7"],
-  "version": "0.8.4"
+  "version": "0.8.5"
 }


### PR DESCRIPTION
## Problem

Issue #35: on 0.8.4 the Eneco injection price stays null for existing users.

0.8.4 fixed the injection-heading anchor (the July 2026 Eneco cards dropped the `/ VALORISATIE` suffix, so 0.8.3 parsed every Eneco injection to `None`). But probe-based freshness keeps serving the snapshot that 0.8.3 already cached: the July PDF URL has not changed, so `_maybe_refresh_snapshot` reuses the stale `injection=None` snapshot instead of re-parsing. The user sees `injection_price_eur_per_kwh: null` with a fresh July snapshot and no error, until Eneco publishes a new card.

## Fix

Bump `_SNAPSHOT_SCHEMA_VERSION` 12 to 13 so the mis-parsed v12 snapshot is discarded on load and re-fetched with the injection block populated. Same one-time-refetch mechanism used for v9 to v12. Manifest bumped to 0.8.5.

## Verification

- ruff check + format clean, mypy clean
- confirmed a v12 blob is now discarded by `_snapshot_from_dict`
- confirmed the live July flex card parses to `injection.current=0.067` on the fixed code
- 120 relevant tests pass (eneco / injection / snapshot / persist)

Interim workaround for affected users on 0.8.4: run the `be_electricity_prices.refresh` action.